### PR TITLE
Add assertBodyNotContains

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -345,6 +345,15 @@ export class ApiResponse extends Macroable {
   }
 
   /**
+   * Assert response body to match the subset from the
+   * expected body
+   */
+  public assertBodyNotContains(expectedBody: any) {
+    this.ensureHasAssert()
+    this.assert!.notContainsSubset(this.body(), expectedBody)
+  }
+
+  /**
    * Assert response to contain a given cookie and optionally
    * has the expected value
    */

--- a/src/response.ts
+++ b/src/response.ts
@@ -345,7 +345,7 @@ export class ApiResponse extends Macroable {
   }
 
   /**
-   * Assert response body to match the subset from the
+   * Assert response body not to match the subset from the
    * expected body
    */
   public assertBodyNotContains(expectedBody: any) {

--- a/tests/response/assertions.spec.ts
+++ b/tests/response/assertions.spec.ts
@@ -103,11 +103,7 @@ test.group('Response | assertions', (group) => {
     httpServer.onRequest((_, res) => {
       res.statusCode = 200
       res.setHeader('content-type', 'application/json')
-      res.end(
-        JSON.stringify([
-          { message: 'hello world', time: new Date() },
-        ])
-      )
+      res.end(JSON.stringify([{ message: 'hello world', time: new Date() }]))
     })
 
     const request = new ApiRequest(

--- a/tests/response/assertions.spec.ts
+++ b/tests/response/assertions.spec.ts
@@ -97,6 +97,28 @@ test.group('Response | assertions', (group) => {
     response.assertBodyContains([{ message: 'hello world' }, { message: 'hi world' }])
   })
 
+  test('assert response body not subset', async ({ assert }) => {
+    assert.plan(1)
+
+    httpServer.onRequest((_, res) => {
+      res.statusCode = 200
+      res.setHeader('content-type', 'application/json')
+      res.end(
+        JSON.stringify([
+          { message: 'hello world', time: new Date() },
+        ])
+      )
+    })
+
+    const request = new ApiRequest(
+      { baseUrl: httpServer.baseUrl, method: 'GET', endpoint: '/' },
+      assert
+    )
+
+    const response = await request
+    response.assertBodyNotContains([{ message: 'hi world' }])
+  })
+
   test('assert response body when response is not json', async ({ assert }) => {
     httpServer.onRequest((_, res) => {
       res.statusCode = 401


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#### Details

I added the `assertBodyNotContains` instance method to response. This is the opposite of `assertBodyContains`. It uses `assert.notContainsSubset` under the hood.

Tests are passing locally.

#### Why

When dealing with a lot of validations (let's say 5 regexes), it makes sense to test against one regex at the time. To do this, we can either assert the body contains all the other rules but we can't make sure the concerned regex is not failing. This PR aims to achieve this without any breaking changes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### Additional information

If this PR gets merged, I'll make a PR to the japa docs.

cc @thetutlage 
