### PR TITLE
feat: 500+ error handling

### DIFF
--- a/src/request.ts
+++ b/src/request.ts
@@ -24,13 +24,7 @@ import {
   SuperAgentSerializer,
   ApiRequestHooks,
 } from './types.js'
-import {
-  dumpRequest,
-  dumpRequestBody,
-  dumpRequestCookies,
-  dumpRequestHeaders,
-  stackToError,
-} from './utils.js'
+import { dumpRequest, dumpRequestBody, dumpRequestCookies, dumpRequestHeaders } from './utils.js'
 
 const DUMP_CALLS = {
   request: dumpRequest,
@@ -176,13 +170,9 @@ export class ApiRequest extends Macroable {
       }
 
       /**
-       * Raise exception when received 500 status code from the server
+       * For all HTTP errors (including 500+), return the error response
+       * This allows proper handling of server errors via ApiResponse
        */
-      if (error.response.status >= 500) {
-        await this.#setupRunner.cleanup(error, this)
-        throw stackToError(error.response.text)
-      }
-
       response = error.response
     }
 

--- a/tests/response/error_handling.spec.ts
+++ b/tests/response/error_handling.spec.ts
@@ -37,18 +37,34 @@ test.group('Response | error handling', (group) => {
     assert.equal(response.status(), 401)
   })
 
-  test('raise fatal errors raised by the server', async ({ assert }) => {
+  test('returns ApiResponse for 500 errors', async ({ assert }) => {
     httpServer.onRequest((_, res) => {
-      try {
-        throw new Error('Something went wrong')
-      } catch (error) {
-        res.statusCode = 500
-        res.end(error.stack)
-      }
+      res.statusCode = 500
+      res.end('Internal server error')
     })
 
     const request = new ApiRequest({ baseUrl: httpServer.baseUrl, method: 'GET', endpoint: '/' })
+    const response = await request
 
-    await assert.rejects(() => request, 'Error: Something went wrong')
+    assert.equal(response.status(), 500)
+    assert.isTrue(response.hasFatalError())
+    assert.isTrue(response.hasServerError())
+  })
+
+  test('handles server errors with response body', async ({ assert }) => {
+    httpServer.onRequest((_, res) => {
+      res.statusCode = 500
+      res.setHeader('Content-Type', 'application/json')
+      res.end(JSON.stringify({ error: 'Something went wrong', code: 'INTERNAL_ERROR' }))
+    })
+
+    const request = new ApiRequest({ baseUrl: httpServer.baseUrl, method: 'GET', endpoint: '/' })
+    const response = await request
+
+    assert.equal(response.status(), 500)
+    assert.deepEqual(response.body(), {
+      error: 'Something went wrong',
+      code: 'INTERNAL_ERROR',
+    })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Issue : https://github.com/japa/api-client/issues/3

It's not an open issue but as I was reading the comments you seems interested in this changes.

### ❓ Type of change
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves : https://github.com/japa/api-client/issues/3

#### Context
Currently, requests that receive 500+ status codes throw an error instead of returning an ApiResponse object.
This makes it difficult to test and handle server errors in a consistent way.

#### Changes
- Modified error handling to treat 500+ errors like other HTTP errors
- All HTTP errors now return an ApiResponse object
- Added tests for server error handling

#### Benefits
- Consistent error handling across all HTTP status codes
- Easier testing of server error scenarios

#### Breaking Changes
- Requests that receive 500+ status codes no longer throw errors
- Code that was catching 500+ errors will need to check response.hasFatalError() instead

#### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

I am ready to open a PR on the doc if this one is merged.
It's my first "real"' open-source PR, feel free to point out any mistakes or improvements I can make to it 😄 