### PR TITLE
fix: allow unstrict case for response header getter

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -154,6 +154,7 @@ export class ApiResponse extends Macroable {
    * Read value for a given response header
    */
   header(key: string): string | undefined {
+    key = key.toLowerCase()
     return this.response.headers[key]
   }
 


### PR DESCRIPTION
Closes: https://github.com/japa/api-client/issues/11

<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

#11

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
