### PR TITLE
fix: normalize header name in assertHeader & assertHeaderMissing

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -393,6 +393,7 @@ export class ApiResponse extends Macroable {
    * has the expected value
    */
   assertHeader(name: string, value?: any) {
+    name = name.toLowerCase()
     this.#ensureHasAssert()
     this.assert!.property(this.headers(), name)
 
@@ -405,6 +406,7 @@ export class ApiResponse extends Macroable {
    * Assert response to not contain a given header
    */
   assertHeaderMissing(name: string) {
+    name = name.toLowerCase()
     this.#ensureHasAssert()
     this.assert!.notProperty(this.headers(), name)
   }

--- a/tests/response/assertions.spec.ts
+++ b/tests/response/assertions.spec.ts
@@ -104,11 +104,12 @@ test.group('Response | assertions', (group) => {
   })
 
   test('assert response headers', async ({ assert }) => {
-    assert.plan(2)
+    assert.plan(5)
 
     httpServer.onRequest((_, res) => {
       res.statusCode = 200
       res.setHeader('content-type', 'text/plain')
+      res.setHeader('Access-Control-Allow-Origin', '*')
       res.end('hello world')
     })
 
@@ -119,6 +120,9 @@ test.group('Response | assertions', (group) => {
 
     const response = await request
     response.assertHeader('content-type')
+    response.assertHeader('Content-Type')
+    response.assertHeader('access-control-allow-origin')
+    response.assertHeader('Access-Control-Allow-Origin')
     response.assertHeaderMissing('authorization')
   })
 


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/japa/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

Closes #14 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Similarly to this PR https://github.com/japa/api-client/pull/12, both `Response#assertHeader()` and `Response#assertHeaderMissing()` are strictly checking the existence of the header before calling `Response#header()`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
